### PR TITLE
fix: Scala 3 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ inThisBuild(
     pgpSecretRing := file("/tmp/secret.asc"),
 
     intellijPluginName := "zio-direct-intellij",
-    intellijBuild := "223",
+    intellijBuild := "241.14494.240",
     jbrInfo := AutoJbr(explicitPlatform = Some(JbrPlatform.osx_aarch64)),
     organization := "dev.zio"
   ) ++ {
@@ -32,7 +32,7 @@ inThisBuild(
   }
 )
 
-lazy val scala213           = "2.13.10"
+lazy val scala213           = "2.13.13"
 
 
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.0
+sbt.version=1.9.9

--- a/src/main/scala/intellij/Extractors.scala
+++ b/src/main/scala/intellij/Extractors.scala
@@ -1,15 +1,13 @@
 package intellij
 
-import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScExpression, ScMethodCall, ScReferenceExpression}
+import org.jetbrains.plugins.scala.codeInspection.collections._
+import org.jetbrains.plugins.scala.extensions.PsiClassExt
+import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScExpression, ScReferenceExpression}
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunctionDefinition
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.ScNamedElement
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScObject, ScTemplateDefinition, ScTrait}
 import org.jetbrains.plugins.scala.lang.psi.types.ScType
 import org.jetbrains.plugins.scala.lang.refactoring.util.ScalaNamesUtil
-import org.jetbrains.plugins.scala.extensions.PsiClassExt
-import org.jetbrains.plugins.scala.codeInspection.collections.{isOfClassFrom, _}
-
-import scala.reflect.ClassTag
 
 object Extractors {
   object Internal {
@@ -50,7 +48,9 @@ object Extractors {
           case f: ScFunctionDefinition =>
             // If it's an extension method an it's in a top-level package, it won't have a containingClass
             // so need to get the qualifier of the extensionMethodOwner
-            Option(f.containingClass).collect { case o: ScObject => o.qualifiedName }.filter(types.contains)
+            Option(f.containingClass).collect {
+              case o @ (_: ScObject | _: ScTrait)=> o.qualifiedName
+            }.filter(types.contains)
           case _ => None
         }
     }
@@ -125,7 +125,7 @@ object Extractors {
     final class DirectExtensionMemberReference(refName: String) extends ExtensionMemberReference(`zio.direct.<extension-method>`, refName)
 
     object `zio.direct.defer.<method>` extends StaticMemberReferenceExtractor {
-      override val types: Set[String] = Set("zio.direct.defer")
+      override val types: Set[String] = Set("zio.direct.defer", "zio.direct.deferCall")
     }
     object `zio.direct.<extension-method>` extends ExtensionMemberReferenceExtractor {
       override val types: Set[String] = Set("zio.direct")

--- a/src/main/scala/intellij/ZioDirectMacroSupport.scala
+++ b/src/main/scala/intellij/ZioDirectMacroSupport.scala
@@ -8,7 +8,6 @@ import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunction
 import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory
 import org.jetbrains.plugins.scala.lang.psi.types.ScType
-import org.jetbrains.plugins.scala.lang.psi.types.api.designator.ScDesignatorType
 import org.jetbrains.plugins.scala.lang.psi.types.api.{Any, Nothing, ParameterizedType}
 
 import scala.collection.mutable.ArrayBuffer
@@ -211,7 +210,12 @@ class ZioDirectMacroSupport extends ScalaMacroTypeable {
       MacroImpl("tpe", "zio.direct.defer"),
       MacroImpl("info", "zio.direct.defer"),
       MacroImpl("verbose", "zio.direct.defer"),
-      MacroImpl("verboseTree", "zio.direct.defer")
+      MacroImpl("verboseTree", "zio.direct.defer"),
+      // Scala 3 below
+      MacroImpl("apply", "zio.direct.deferCall"),
+      MacroImpl("info", "zio.direct.deferCall"),
+      MacroImpl("verbose", "zio.direct.deferCall"),
+      MacroImpl("verboseTree", "zio.direct.deferCall")
     )
   }
 }

--- a/src/test/scala/ZioDirectMacroSupportTestScala2.scala
+++ b/src/test/scala/ZioDirectMacroSupportTestScala2.scala
@@ -1,0 +1,10 @@
+import org.jetbrains.plugins.scala.ScalaVersion
+
+class ZioDirectMacroSupportTestScala2 extends BaseZioDirectMacroSupportTest {
+
+  override def injectedScalaVersion = Some(ScalaVersion.Latest.Scala_2_13)
+
+  def test_defer_tpe(): Unit = {
+    doTest("""defer.tpe { val a = ZIO.service[ConfigA].run.value; a }""", "ZIO[ConfigA, Nothing, java.lang.String")
+  }
+}

--- a/src/test/scala/ZioDirectMacroSupportTestScala3Latest.scala
+++ b/src/test/scala/ZioDirectMacroSupportTestScala3Latest.scala
@@ -1,0 +1,5 @@
+import org.jetbrains.plugins.scala.ScalaVersion
+
+class ZioDirectMacroSupportTestScala3Latest extends BaseZioDirectMacroSupportTest {
+  override def injectedScalaVersion = Some(ScalaVersion.Latest.Scala_3_4)
+}

--- a/src/test/scala/ZioDirectMacroSupportTestScala3Lts.scala
+++ b/src/test/scala/ZioDirectMacroSupportTestScala3Lts.scala
@@ -1,0 +1,5 @@
+import org.jetbrains.plugins.scala.ScalaVersion
+
+class ZioDirectMacroSupportTestScala3Lts extends BaseZioDirectMacroSupportTest {
+  override def injectedScalaVersion = Some(ScalaVersion.Latest.Scala_3_LTS)
+}

--- a/src/test/scala/org/jetbrains/plugins/scala/annotator/AnnotatorHolderMock.scala
+++ b/src/test/scala/org/jetbrains/plugins/scala/annotator/AnnotatorHolderMock.scala
@@ -1,6 +1,7 @@
 package org.jetbrains.plugins.scala.annotator
 
 import com.intellij.lang.annotation.{AnnotationSession, HighlightSeverity}
+import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiFile
 import org.jetbrains.annotations.Nls
@@ -9,26 +10,41 @@ import org.jetbrains.plugins.scala.extensions.IterableOnceExt
 import scala.annotation.nowarn
 
 class AnnotatorHolderMock(file: PsiFile) extends AnnotatorHolderMockBase[Message](file) {
-  import Message._
 
-  def errorAnnotations: List[Error] = annotations.filterByType[Error]
+  def errorAnnotations: List[Message.Error] = annotations.filterByType[Message.Error]
 
+  @nowarn("cat=deprecation")
   private val severityMapping: Map[HighlightSeverity, (String, String) => Message] =
     Map(
-      HighlightSeverity.ERROR -> Error.apply,
-      HighlightSeverity.WARNING -> Warning.apply,
-      HighlightSeverity.WEAK_WARNING -> Warning.apply,
-      HighlightSeverity.INFORMATION -> Info.apply,
-      HighlightSeverity.INFO -> Info.apply
-    ): @nowarn("cat=deprecation")
+      HighlightSeverity.ERROR -> Message.Error.apply,
+      HighlightSeverity.WARNING -> Message.Warning.apply,
+      HighlightSeverity.WEAK_WARNING -> Message.Warning.apply,
+      HighlightSeverity.INFORMATION -> Message.Info.apply,
+      HighlightSeverity.INFO -> Message.Info.apply
+    )
 
-  private def textOf(range: TextRange): String =
-    getCurrentAnnotationSession.getFile.getText
-      .substring(range.getStartOffset, range.getEndOffset)
-
-  override def createMockAnnotation(severity: HighlightSeverity, range: TextRange, message: String): Option[Message] = {
+  override def createMockAnnotation(severity: HighlightSeverity, range: TextRange, message: String, enforcedAttributes: TextAttributesKey): Option[Message] = {
     val transformer = severityMapping.get(severity)
-    transformer.map(_.apply(textOf(range), message))
+    transformer.map(_.apply(fileTextOf(range), message))
+  }
+}
+
+
+class AnnotatorHolderExtendedMock(file: PsiFile) extends AnnotatorHolderMockBase[Message2](file) {
+
+  @nowarn("cat=deprecation")
+  private val severityMapping: Map[HighlightSeverity, (TextRange, String, String, TextAttributesKey) => Message2] =
+    Map(
+      HighlightSeverity.ERROR -> Message2.Error.apply,
+      HighlightSeverity.WARNING -> Message2.Warning.apply,
+      HighlightSeverity.WEAK_WARNING -> Message2.Warning.apply,
+      HighlightSeverity.INFORMATION -> Message2.Info.apply,
+      HighlightSeverity.INFO -> Message2.Info.apply
+    )
+
+  override def createMockAnnotation(severity: HighlightSeverity, range: TextRange, message: String, enforcedAttributes: TextAttributesKey): Option[Message2] = {
+    val transformer = severityMapping.get(severity)
+    transformer.map(_.apply(range, fileTextOf(range), message, enforcedAttributes))
   }
 }
 
@@ -38,9 +54,10 @@ abstract class AnnotatorHolderMockBase[T](file: PsiFile) extends ScalaAnnotation
 
   protected var myAnnotations: List[T] = List[T]()
 
-  def createMockAnnotation(severity: HighlightSeverity, range: TextRange, message: String): Option[T]
+  def createMockAnnotation(severity: HighlightSeverity, range: TextRange, message: String, enforcedAttributes: TextAttributesKey): Option[T]
 
-  override def getCurrentAnnotationSession: AnnotationSession = new AnnotationSession(file)
+  //noinspection ApiStatus,UnstableApiUsage
+  override def getCurrentAnnotationSession: AnnotationSession = new AnnotationSession(file): @nowarn("cat=deprecation")
 
   override def isBatchMode: Boolean = false
 
@@ -53,7 +70,12 @@ abstract class AnnotatorHolderMockBase[T](file: PsiFile) extends ScalaAnnotation
   private class DummyAnnotationBuilder(severity: HighlightSeverity, @Nls message: String)
     extends DummyScalaAnnotationBuilder(severity, message) {
 
-    override def onCreate(severity: HighlightSeverity, message: String, range: TextRange): Unit =
-      myAnnotations :::= createMockAnnotation(severity, range, message).toList
+    override def onCreate(severity: HighlightSeverity, message: String, range: TextRange, enforcedAttributes: TextAttributesKey): Unit =
+      myAnnotations :::= createMockAnnotation(severity, range, message, enforcedAttributes).toList
+  }
+
+  protected def fileTextOf(range: TextRange): String = {
+    val fileText = getCurrentAnnotationSession.getFile.getText
+    fileText.substring(range.getStartOffset, range.getEndOffset)
   }
 }

--- a/src/test/scala/org/jetbrains/plugins/scala/annotator/Message2.scala
+++ b/src/test/scala/org/jetbrains/plugins/scala/annotator/Message2.scala
@@ -1,0 +1,63 @@
+package org.jetbrains.plugins.scala.annotator
+
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.util.TextRange
+
+import scala.collection.mutable
+import scala.math.Ordered.orderingToOrdered
+
+/**
+ * Practically the same as `Message` but with range and text attributes
+ * NOTE: ideally we should consider unifying all tests to use single version of test message
+ */
+object Message2 {
+  case class Info(override val range: TextRange, override val code: String, override val message: String, override val textAttributesKey: TextAttributesKey) extends Message2
+  case class Warning(override val range: TextRange, override val code: String, override val message: String, override val textAttributesKey: TextAttributesKey) extends Message2
+  case class Error(override val range: TextRange, override val code: String, override val message: String, override val textAttributesKey: TextAttributesKey) extends Message2
+
+  implicit object TextRangeOrdering extends scala.math.Ordering[TextRange] {
+    override def compare(x: TextRange, y: TextRange): Int =
+      (x.getStartOffset, x.getEndOffset) compare(y.getStartOffset, y.getEndOffset)
+  }
+}
+
+sealed abstract class Message2 extends Ordered[Message2] {
+  /** @return range of annotated code, corresponding */
+  def range: TextRange
+
+  /** @return annotated code, corresponding to [[range]] */
+  def code: String
+
+  /** @return annotation message */
+  def message: String
+
+  def textAttributesKey: TextAttributesKey
+
+  override def compare(that: Message2): Int = {
+    import org.jetbrains.plugins.scala.annotator.Message2.TextRangeOrdering
+
+    import scala.math.Ordered.orderingToOrdered
+
+    (this.range, this.message) compare(that.range, that.message)
+  }
+
+  def textWithRangeAndCodeAttribute: String = buildText(includeRange = true, includeCode = true, includeAttributes = true)
+  def textWithRangeAndAttribute: String = buildText(includeRange = true, includeAttributes = true)
+  def textWithRangeAndMessage: String = buildText(includeRange = true, includeMessage = true)
+
+  private def buildText(
+                         includeRange: Boolean = false,
+                         includeCode: Boolean = false,
+                         includeMessage: Boolean = false,
+                         includeAttributes: Boolean = false,
+                       ): String = {
+    val details = new mutable.ArrayBuffer[String]
+
+    if(includeRange) details.append(range.toString)
+    if(includeCode) details.append(code)
+    if(includeMessage) details.append(message)
+    if(includeAttributes) details.append(textAttributesKey.getExternalName)
+
+    this.getClass.getSimpleName + details.mkString("(", ",", ")")
+  }
+}

--- a/src/test/scala/org/jetbrains/plugins/scala/base/libraryLoaders/IvyManagedLoader.scala
+++ b/src/test/scala/org/jetbrains/plugins/scala/base/libraryLoaders/IvyManagedLoader.scala
@@ -3,8 +3,9 @@ package org.jetbrains.plugins.scala.base.libraryLoaders
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
 import com.intellij.testFramework.PsiTestUtil
-import org.jetbrains.plugins.scala.{DependencyManagerBase, ScalaVersion, TestDependencyManager}
+import org.jetbrains.plugins.scala.{DependencyManagerBase, ScalaVersion}
 import org.jetbrains.plugins.scala.DependencyManagerBase.{DependencyDescription, ResolvedDependency}
+import org.jetbrains.plugins.scala.util.dependencymanager.TestDependencyManager
 
 import scala.annotation.nowarn
 import scala.collection.mutable
@@ -45,7 +46,7 @@ object IvyManagedLoader {
   ] = mutable.Map()
 
   def apply(dependencies: DependencyDescription*): IvyManagedLoader =
-    new IvyManagedLoader(new TestDependencyManager, dependencies: _*)
+    new IvyManagedLoader(TestDependencyManager, dependencies: _*)
 
   def apply(dependencyManager: DependencyManagerBase, dependencies: DependencyDescription*): IvyManagedLoader =
     new IvyManagedLoader(dependencyManager, dependencies: _*)

--- a/src/test/scala/org/jetbrains/plugins/scala/lang/typeInference/TypeInferenceDoTest.scala
+++ b/src/test/scala/org/jetbrains/plugins/scala/lang/typeInference/TypeInferenceDoTest.scala
@@ -12,7 +12,6 @@ import org.jetbrains.plugins.scala.lang.psi.api.base.types.ScTypeElement
 import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression
 import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory
 import org.jetbrains.plugins.scala.lang.psi.types.{ScType, TypePresentationContext}
-import org.jetbrains.plugins.scala.lang.psi.types.api.TypePresentation
 import org.jetbrains.plugins.scala.lang.psi.types.result._
 import org.jetbrains.plugins.scala.project.{ProjectContext, ScalaFeatures}
 import org.jetbrains.plugins.scala.util.TestUtils
@@ -85,7 +84,7 @@ trait TypeInferenceDoTest extends TestCase with FailableTest with ScalaSdkOwner 
     val expectedType =
       ScalaPsiElementFactory.createTypeElementFromText(
         expectedTypeText,
-        ScalaPsiElementFactory.createElementFromText(ctx.prefix, ScalaFeatures.default)(expr.projectContext),
+        ScalaPsiElementFactory.createElementFromText(ctx.prefix, ScalaFeatures.onlyByVersion(version))(expr.projectContext),
         null
       ).`type`()
 

--- a/src/test/scala/org/jetbrains/plugins/scala/util/dependencymanager/TestDependencyManager.scala
+++ b/src/test/scala/org/jetbrains/plugins/scala/util/dependencymanager/TestDependencyManager.scala
@@ -1,0 +1,11 @@
+package org.jetbrains.plugins.scala.util.dependencymanager
+
+import org.jetbrains.plugins.scala.DependencyManagerBase
+
+object TestDependencyManager extends DependencyManagerBase {
+
+  // from Michael M.: this blacklist is in order that tested libraries do not transitively fetch `scala-library`,
+  // which is loaded in a special way in tests via org.jetbrains.plugins.scala.base.libraryLoaders.ScalaSDKLoader
+  //TODO: should we add scala3-* here?
+  override val artifactBlackList: Set[String] = Set("scala-library", "scala-reflect", "scala-compiler")
+}


### PR DESCRIPTION
Added tests for Scala 3 LTS and Scala 3.4 and fixed type inference for those versions. Current production version infers everything on Scala 3 as `ZIO[_, _, _]`.

Changes outside of `src/main/scala` were required to make it compile with the newest intellij build and plugin.